### PR TITLE
add random to white-list

### DIFF
--- a/run-lang.rkt
+++ b/run-lang.rkt
@@ -148,6 +148,7 @@
    negative?
    list
    shuffle
+   random
    length
    first
    second


### PR DESCRIPTION
add random to white-list because shuffle is there, and we don't want people defining their own random that works by making a list to shuffle.